### PR TITLE
Bug-fix: File type (image) and size limit

### DIFF
--- a/src/components/CreateModal/CreateModal.jsx
+++ b/src/components/CreateModal/CreateModal.jsx
@@ -320,13 +320,13 @@ export default function CreateModal({
   const handleItemImageChange = useCallback(
     (e) => {
       // image size limit of 2 MB
-      if(e.target.files[0].size <= 2000000){
+      if (e.target.files[0].size <= 10000000) {
         setNewAddedItem((prev) => ({
           ...prev,
-            image: e.target.files[0],
+          image: e.target.files[0],
         }));
       } else {
-        alert("Image exceeds size limit of 2 MB")
+        alert("Image exceeds size limit of 10 MB");
       }
     },
     [setNewAddedItem]

--- a/src/components/CreateModal/CreateModal.jsx
+++ b/src/components/CreateModal/CreateModal.jsx
@@ -319,10 +319,15 @@ export default function CreateModal({
   // Define the callback function to change the item image
   const handleItemImageChange = useCallback(
     (e) => {
-      setNewAddedItem((prev) => ({
-        ...prev,
-        image: e.target.files[0],
-      }));
+      // image size limit of 2 MB
+      if(e.target.files[0].size <= 2000000){
+        setNewAddedItem((prev) => ({
+          ...prev,
+            image: e.target.files[0],
+        }));
+      } else {
+        alert("Image exceeds size limit of 2 MB")
+      }
     },
     [setNewAddedItem]
   );
@@ -523,6 +528,7 @@ export default function CreateModal({
                       <Flex justifyContent="center" alignItems="center" gap={3}>
                         <Input
                           type="file"
+                          accept="image/*"
                           multiple
                           width="38%"
                           sx={{


### PR DESCRIPTION
Fixed file upload bug by:

- Requiring an `image` file
- Limiting the image size to `2 MB` and raising an alert if it exceeds that limit

Closes #19 