### PR TITLE
Add security to database for item contact email

### DIFF
--- a/src/components/InfoModal/InfoModal.jsx
+++ b/src/components/InfoModal/InfoModal.jsx
@@ -18,7 +18,7 @@ import DataContext from "../../context/DataContext";
 import ImageContainer from "../ImageContainer/ImageContainer";
 import FeedbackModal from "../FeedbackModal/FeedbackModal";
 import { LinkIcon, CheckIcon, EmailIcon } from "@chakra-ui/icons";
-import { deleteItem } from "../../utils/ApiUtils";
+import { getItemEmail, deleteItem } from "../../utils/ApiUtils";
 // import axios from "axios";
 
 export default function InfoModal({
@@ -29,6 +29,7 @@ export default function InfoModal({
   setLeaderboard,
 }) {
   const [showEmail, setShowEmail] = useState(false);
+  const [itemEmail, setItemEmail] = useState("");
   const [isShared, setIsShared] = useState(false);
   const { onLoginModalOpen, token, setLoading } = useContext(DataContext);
   const { user } = UserAuth();
@@ -60,23 +61,25 @@ export default function InfoModal({
   const handleClose = useCallback(() => {
     onClose();
     navigate("/");
-  }, [onClose, navigate])
-  
+  }, [onClose, navigate]);
+
   // Reveals the email of the user who posted the item
   const handleShowEmail = useCallback(() => {
     if (user) {
+      // Retrieves the email of the item poster
+      getItemEmail(props, token).then((itemsData) => {
+        setItemEmail(itemsData.data);
+      });
       setShowEmail(true);
     } else {
       onLoginModalOpen();
     }
-  }, [user, onLoginModalOpen])
+  }, [user, props, token, onLoginModalOpen]);
 
   // Copies the url of the item to the clipboard
   const handleShare = useCallback(() => {
     setIsShared(true);
-    navigator.clipboard.writeText(
-      `https://zotnfound.com/${props.id}`
-    );
+    navigator.clipboard.writeText(`https://zotnfound.com/${props.id}`);
   }, [props.id]);
 
   // The "Owner" tag for an item - only visible to the user who posted the item
@@ -86,8 +89,8 @@ export default function InfoModal({
         Owner
       </Tag>
     </Flex>
-  )
-  
+  );
+
   // The "Lost" tag for an item - visible to all users
   const lostTag = (
     <Flex>
@@ -95,8 +98,8 @@ export default function InfoModal({
         Lost
       </Tag>
     </Flex>
-  )
-  
+  );
+
   // The "Found" tag for an item - visible to all users
   const foundTag = (
     <Flex>
@@ -104,41 +107,38 @@ export default function InfoModal({
         Found
       </Tag>
     </Flex>
-  )
-  
+  );
+
   // The date that the item was lost - visible to all users
-  const lostDateText = (
-    <Text color={"gray.500"}>Lost on {props.itemdate}</Text>
-  )
+  const lostDateText = <Text color={"gray.500"}>Lost on {props.itemdate}</Text>;
 
   // The date that the item was found - visible to all users
   const foundDateText = (
     <Text color={"gray.500"}> Found on {props.itemdate}</Text>
-  )
-  
+  );
+
   /*
   The "View Contact" button for an item - visible to all users with an @uci.edu email.
   Doesn't reveal the email of the user who posted the item, only indicates that the user can view the email
   */
   const viewContactButton = (
     <Button
-    colorScheme="blue"
-    size={"lg"}
-    gap={2}
-    isDisabled={props.isresolved && true}
-    onClick={handleShowEmail}
+      colorScheme="blue"
+      size={"lg"}
+      gap={2}
+      isDisabled={props.isresolved && true}
+      onClick={handleShowEmail}
     >
-    <EmailIcon /> View Contact
-  </Button>
-  )
-  
-  
+      <EmailIcon /> View Contact
+    </Button>
+  );
+
   //Shows the email of the user who posted the item - visible to all users with an @uci.edu email AND if the user has clicked the "View Contact" button
   const showContactButton = (
     <Button size="lg" variant="outline" colorScheme="blue">
-    {props.email}
-  </Button>
-  )
+      {itemEmail}
+    </Button>
+  );
 
   const formattedDate = formatDate(new Date(props.date));
   return (
@@ -184,13 +184,11 @@ export default function InfoModal({
                 </Heading>
 
                 <Flex gap={2}>
-                  {currentEmail === props.email ? (
-                    ownerTag
-                  ) : props.islost ? (
-                    lostTag
-                  ) : (
-                    foundTag
-                  )}
+                  {currentEmail === props.email
+                    ? ownerTag
+                    : props.islost
+                    ? lostTag
+                    : foundTag}
                   <Text color={"gray.500"}>Posted: {formattedDate}</Text>
                 </Flex>
               </Flex>
@@ -202,11 +200,7 @@ export default function InfoModal({
                 <Text as={"b"} fontSize={"xl"}>
                   Description:
                 </Text>
-                {props.islost ? (
-                  lostDateText
-                ) : (
-                  foundDateText
-                )}
+                {props.islost ? lostDateText : foundDateText}
                 <Text
                   fontSize={"md"}
                   mt={3}
@@ -220,11 +214,7 @@ export default function InfoModal({
 
               <Flex gap={5} justifyContent={"center"} alignItems={"center"}>
                 {currentEmail !== props.email &&
-                  (!showEmail ? (
-                    viewContactButton
-                  ) : (
-                    showContactButton
-                  ))}
+                  (!showEmail ? viewContactButton : showContactButton)}
                 {currentEmail === props.email && (
                   <Button
                     colorScheme="green"

--- a/src/utils/ApiUtils.js
+++ b/src/utils/ApiUtils.js
@@ -6,6 +6,17 @@ export const getItems = async () => {
     .catch((err) => console.log(err));
 };
 
+// Get email associated with item id
+export const getItemEmail = (props, token) => {
+  return axios
+    .get(`${process.env.REACT_APP_AWS_BACKEND_URL}/items/${props.id}/email`, {
+      headers: {
+        Authorization: `Bearer ${token}`, // verify auth
+      },
+    })
+    .catch((err) => console.log(err));
+};
+
 export const getLeaderboard = async () => {
   return axios
     .get(`${process.env.REACT_APP_AWS_BACKEND_URL}/leaderboard/`)


### PR DESCRIPTION
- When "View Contact" button is clicked, send GET request to `/items/:id/email`
- Gets email associated with item if user is logged in
<img width="426" alt="ss" src="https://github.com/icssc/zotnfound-frontend/assets/60823208/3604d72e-973b-41a0-8418-63aaec1318c9">

Closes #20 