### PR TITLE
28 feat date range filter button

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -598,7 +598,7 @@ export default function Home() {
               </Alert>
             </Flex>
           ) : (
-            <>
+            <Flex gap="4">
               <Button
                 backgroundColor="white"
                 variant="outline"
@@ -632,7 +632,7 @@ export default function Home() {
                   color="#74a2fa"
                   fontSize={{ base: "xl", md: "2xl" }}
                   size="lg"
-                  gap={2}
+                  // gap={2}
                   borderRadius={"lg"}
                 >
                   {DateRangeFilter}
@@ -746,7 +746,7 @@ export default function Home() {
                   <DrawerFooter></DrawerFooter>
                 </DrawerContent>
               </Drawer>
-            </>
+            </Flex>
           )}
         </Flex>
         <Flex position="absolute">

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import Map from "../Map/Map";
 import "./Home.css";
 import Filter from "../Filter/Filter";
@@ -197,6 +197,28 @@ export default function Home() {
     getData();
   }, [user]);
 
+  // retrieve a list of items from the last 7 days
+  const retrieveItemsWithinWeek = useCallback(() => {
+    axios
+      .get(`${process.env.REACT_APP_AWS_BACKEND_URL}/items/week`)
+      .then((obj) => {
+        setData(obj.data.map((item) => ({ ...item, id: item.id })));
+      })
+      .catch((err) => console.log(err));
+  },[]);
+
+  // retrieve a list of items from the last year
+  const retrieveItemsWithinYear = useCallback((e) => {
+    console.log("year got entered here 1");
+    axios
+      .get(`${process.env.REACT_APP_AWS_BACKEND_URL}/items/year`)
+      .then((obj) => {
+        console.log("year got entered here 2");
+        setData(obj.data.map((item) => ({ ...item, id: item.id })));
+      })
+      .catch((err) => console.log("Error Here", err));
+  },[]);
+
   //LEADERBOARD GET INFO
   useEffect(() => {
     const getLeaderboard = async () => {
@@ -252,6 +274,8 @@ export default function Home() {
       setToken(user.accessToken);
     }
   }, [user]);
+
+
 
   window.onresize = () => {
     setScreenWidth(window.screen.width);
@@ -561,6 +585,38 @@ export default function Home() {
                 isOpen={isOpen}
                 onClose={onClose}
               />
+              <Menu>
+                <MenuButton
+                  as={Button}
+                  backgroundColor="white"
+                  variant="outline"
+                  boxShadow="7px 7px 14px #666666,
+                -7px -7px 14px #ffffff;"
+                  color="#74a2fa"
+                  fontSize={{ base: "xl", md: "2xl" }}
+                  size="lg"
+                  gap={2}
+                  borderRadius={"lg"}
+                >
+                  Date Range Filter
+                </MenuButton>
+                <MenuList>
+                  <MenuItem>All</MenuItem>
+                  <MenuItem 
+                  onClick={retrieveItemsWithinWeek}
+                  >
+                    Last Week
+                  </MenuItem>
+                  <MenuItem>Last 2 Weeks</MenuItem>
+                  <MenuItem>Last Month</MenuItem>
+                  <MenuItem
+                    onClick={retrieveItemsWithinYear}
+                  >
+                    Last Year
+                  </MenuItem>
+                </MenuList>
+              </Menu>
+
               <Button
                 display={{ md: "none" }}
                 background={"#74a2fa"}
@@ -573,9 +629,11 @@ export default function Home() {
                 justifyContent={"center"}
                 alignItems={"center"}
               >
-                <StarIcon />
+                <StarIcon /> 
+                {/* What is this button? */}
               </Button>
 
+              
               <Drawer
                 isOpen={isResultsBarOpen}
                 placement="right"

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -113,7 +113,7 @@ export default function Home() {
   const [focusLocation, setFocusLocation] = useState();
   const [screenWidth, setScreenWidth] = useState(window.screen.width);
   const [uploadImg, setUploadImg] = useState("");
-
+  const [DateRangeFilter, setDateRangeFilter] = useState("Date Range Filter");
   // LOGIN MODAL
   const {
     isOpen: isLoginModalOpen,
@@ -197,28 +197,64 @@ export default function Home() {
     getData();
   }, [user]);
 
+  // retrieve a list of items ALL TIME
+  const retrieveItemsAllTime = useCallback(() => {
+    axios
+      .get(`${process.env.REACT_APP_AWS_BACKEND_URL}/items/`)
+      .then((obj) => {
+        setData(obj.data.map((item) => ({ ...item, id: item.id })));
+        setDateRangeFilter("All");
+      })
+      .catch((err) => console.log(err));
+  },[]);
+
   // retrieve a list of items from the last 7 days
   const retrieveItemsWithinWeek = useCallback(() => {
     axios
       .get(`${process.env.REACT_APP_AWS_BACKEND_URL}/items/week`)
       .then((obj) => {
         setData(obj.data.map((item) => ({ ...item, id: item.id })));
+        setDateRangeFilter("Last 7 Days");
       })
       .catch((err) => console.log(err));
   },[]);
 
+  // retrieve a list of items from the last 2 weeks
+  const retrieveItemsWithinTwoWeeks = useCallback(() => {
+    axios
+      .get(`${process.env.REACT_APP_AWS_BACKEND_URL}/items/two_weeks`)
+      .then((obj) => {
+        setData(obj.data.map((item) => ({ ...item, id: item.id })));
+        setDateRangeFilter("Last 14 Days");
+      })
+      .catch((err) => console.log(err));
+  },[]);
+
+  // retrieve a list of items from the last month
+  const retrieveItemsWithinMonth = useCallback(() => {
+    axios
+      .get(`${process.env.REACT_APP_AWS_BACKEND_URL}/items/month`)
+      .then((obj) => {
+        setData(obj.data.map((item) => ({ ...item, id: item.id })));
+        setDateRangeFilter("Last 30 Days");
+      })
+      .catch((err) => console.log(err)); 
+  },[]);
+
   // retrieve a list of items from the last year
-  const retrieveItemsWithinYear = useCallback((e) => {
+  const retrieveItemsWithinYear = useCallback(() => {
     console.log("year got entered here 1");
     axios
       .get(`${process.env.REACT_APP_AWS_BACKEND_URL}/items/year`)
       .then((obj) => {
         console.log("year got entered here 2");
         setData(obj.data.map((item) => ({ ...item, id: item.id })));
+        setDateRangeFilter("This Year");
       })
       .catch((err) => console.log("Error Here", err));
   },[]);
 
+  
   //LEADERBOARD GET INFO
   useEffect(() => {
     const getLeaderboard = async () => {
@@ -588,6 +624,7 @@ export default function Home() {
               <Menu>
                 <MenuButton
                   as={Button}
+                  rightIcon={<ChevronDownIcon />}
                   backgroundColor="white"
                   variant="outline"
                   boxShadow="7px 7px 14px #666666,
@@ -598,21 +635,33 @@ export default function Home() {
                   gap={2}
                   borderRadius={"lg"}
                 >
-                  Date Range Filter
+                  {DateRangeFilter}
                 </MenuButton>
                 <MenuList>
-                  <MenuItem>All</MenuItem>
-                  <MenuItem 
-                  onClick={retrieveItemsWithinWeek}
+                  <MenuItem
+                    onClick={retrieveItemsAllTime}
                   >
-                    Last Week
+                    All
                   </MenuItem>
-                  <MenuItem>Last 2 Weeks</MenuItem>
-                  <MenuItem>Last Month</MenuItem>
                   <MenuItem
                     onClick={retrieveItemsWithinYear}
                   >
-                    Last Year
+                    This Year
+                  </MenuItem>
+                  <MenuItem 
+                  onClick={retrieveItemsWithinWeek}
+                  >
+                    Last 7 Days
+                  </MenuItem>
+                  <MenuItem
+                    onClick={retrieveItemsWithinTwoWeeks}
+                  >
+                    Last 14 Days
+                  </MenuItem>
+                  <MenuItem
+                    onClick={retrieveItemsWithinMonth}
+                  >
+                    Last 30 Days
                   </MenuItem>
                 </MenuList>
               </Menu>
@@ -630,7 +679,6 @@ export default function Home() {
                 alignItems={"center"}
               >
                 <StarIcon /> 
-                {/* What is this button? */}
               </Button>
 
               


### PR DESCRIPTION
### Changes
Added a menu component with options: **All, This Year, Last 7 Days, Last 14 Days, Last 30 Days**.
Had to wrap the filter button and new menu component with a **Flex** in order to keep them directly next to each other.
### New Callback Functions
`retrieveItemsAllTime`                --> for the 'all' option, calls `/items/` endpoint

`retrieveItemsWithinWeek`         --> for the '7 days' option, calls the `/items/week` endpoint

`retrieveItemsWithinTwoWeeks`  --> for the '14 Days' option, calls the `/items/two_weeks` endpoint

`retrieveItemsWithinMonth`        --> for the '30 Days' option, calls the `/items/month` endpoint

`retrieveItemsWithinYear`             --> for the 'This Year' option, calls the `/items/year` endpoint
