### PR TITLE
feat: map button refactor

### DIFF
--- a/src/components/Home/DateRangeFilter.jsx
+++ b/src/components/Home/DateRangeFilter.jsx
@@ -21,13 +21,14 @@ export default function DateRangeFilter() {
         as={Button}
         rightIcon={<ChevronDownIcon />}
         backgroundColor="white"
+        colorScheme="twitter"
         variant="outline"
-        boxShadow="7px 7px 14px #666666,
-                -7px -7px 14px #ffffff;"
+        boxShadow="5px 2px 9px rgba(0, 0, 0, 0.3);"
         color="#74a2fa"
         fontSize={{ base: "xl", md: "2xl" }}
         size="lg"
         // gap={2}
+        borderWidth={2}
         borderRadius={"lg"}
       >
         {DateRangeFilter}

--- a/src/components/Home/DateRangeFilter.jsx
+++ b/src/components/Home/DateRangeFilter.jsx
@@ -21,13 +21,8 @@ export default function DateRangeFilter() {
         as={Button}
         rightIcon={<ChevronDownIcon />}
         backgroundColor="white"
-        colorScheme="twitter"
-        variant="outline"
-        boxShadow="5px 2px 9px rgba(0, 0, 0, 0.3);"
-        color="#74a2fa"
-        fontSize={{ base: "xl", md: "2xl" }}
         size="lg"
-        // gap={2}
+        fontSize={{ base: "xl", md: "2xl" }}
         borderWidth={2}
         borderRadius={"lg"}
       >

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -477,17 +477,18 @@ export default function Home() {
             <Flex gap="4">
               <Button
                 backgroundColor="white"
+                colorScheme="twitter"
                 variant="outline"
-                boxShadow="7px 7px 14px #666666,
-                -7px -7px 14px #ffffff;"
+                boxShadow="5px 2px 9px rgba(0, 0, 0, 0.3);"
                 color="#74a2fa"
                 onClick={onOpen}
                 fontSize={{ base: "xl", md: "2xl" }}
                 size="lg"
                 gap={2}
                 borderRadius={"lg"}
+                borderWidth={2}
+                leftIcon={<SettingsIcon />}
               >
-                <SettingsIcon />
                 Filter
               </Button>
               <Filter

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -10,6 +10,7 @@ import {
   InputGroup,
   InputLeftAddon,
   Button,
+  ButtonGroup,
   Flex,
   HStack,
   Text,
@@ -475,22 +476,28 @@ export default function Home() {
             </Flex>
           ) : (
             <Flex gap="4">
-              <Button
-                backgroundColor="white"
-                colorScheme="twitter"
+              <ButtonGroup
                 variant="outline"
-                boxShadow="5px 2px 9px rgba(0, 0, 0, 0.3);"
+                colorScheme="twitter"
                 color="#74a2fa"
-                onClick={onOpen}
-                fontSize={{ base: "xl", md: "2xl" }}
-                size="lg"
-                gap={2}
-                borderRadius={"lg"}
-                borderWidth={2}
-                leftIcon={<SettingsIcon />}
+                spacing={6}
+                boxShadow="5px 2px 9px rgba(0, 0, 0, 0.2);"
               >
-                Filter
-              </Button>
+                <Button
+                  backgroundColor="white"
+                  onClick={onOpen}
+                  size="lg"
+                  gap={2}
+                  fontSize={{ base: "xl", md: "2xl" }}
+                  borderRadius={"lg"}
+                  borderWidth={2}
+                  leftIcon={<SettingsIcon />}
+                >
+                  Filter
+                </Button>
+                <DateRangeFilter />
+              </ButtonGroup>
+
               <Filter
                 setFindFilter={setFindFilter}
                 findFilter={findFilter}
@@ -498,8 +505,6 @@ export default function Home() {
                 isOpen={isOpen}
                 onClose={onClose}
               />
-
-              <DateRangeFilter />
 
               <Button
                 display={{ md: "none" }}


### PR DESCRIPTION
### Overview

- added styles to setting and date filter buttons
- reduced the box shadow
- grouped using `ButtonGroup` Chakra component for group styles applied to both buttons

### Future improvements

Move the buttons and related components into its own component called something like `MapButtons` or `SettingsButtons` or anything fit.

Overall, I think refactoring should be more about compartmentalizing components. Because components should not be hundreds of lines long, maybe future discussion on this.
<img width="327" alt="Screenshot 2024-02-23 at 4 50 01 AM" src="https://github.com/icssc/zotnfound-frontend/assets/66880934/99f6026b-176f-4361-8872-e2eff3e770dd">
<img width="1373" alt="Screenshot 2024-02-23 at 4 50 14 AM" src="https://github.com/icssc/zotnfound-frontend/assets/66880934/c644d7dd-3e3e-4d64-a94f-878577598004">
