### PR TITLE
feat: made lost item category menu items responsive

### DIFF
--- a/src/components/Type/TypeCard.jsx
+++ b/src/components/Type/TypeCard.jsx
@@ -19,8 +19,8 @@ export default function TypeCard({
       backgroundColor={newAddedItem.type === type ? "#787092" : "white"}
       variant="outline"
       border="5px rgb(166, 152, 216) solid"
-      minW={{ md: "7vw", base: "13vh" }}
-      minH={{ md: "7vw", base: "13vh" }}
+      minW={{ md: "10vw", base: "13vh" }}
+      minH={{ md: "8vw", base: "13vh" }}
       borderRadius="20px"
       alignItems={"center"}
       justifyContent={"center"}

--- a/src/components/TypeSelector/TypeSelector.jsx
+++ b/src/components/TypeSelector/TypeSelector.jsx
@@ -24,11 +24,11 @@ export default function TypeSelector(props) {
 
   return (
     <Flex
-      w={{ md: "50vw", base: "100%" }}
+      w={{ xl: "700px", lg: "600px" }}
       flexWrap={"wrap"}
       alignItems={"center"}
       justifyContent={"center"}
-      paddingX={{ md: "20%", base: "0%" }}
+      padding={{ base: "30px" }}
       gap={{ md: 10, base: 4 }}
       m={0}
     >


### PR DESCRIPTION
### Overview

In 2nd step of `CreateModal`, the menu items for the lost item categories were sticking out on `xl` screen width, so this PR resolved this issue as well as made the items responsive.