### PR TITLE
feat: moved add item button

### DIFF
--- a/src/components/CreateModal/CreateModal.jsx
+++ b/src/components/CreateModal/CreateModal.jsx
@@ -59,7 +59,6 @@ export default function CreateModal({
   upload,
 }) {
   const { user } = UserAuth();
-  const { onLoginModalOpen } = useContext(DataContext);
   const [isLoading, setIsLoading] = useState(false);
 
   const uploadFile = useCallback(() => {
@@ -102,70 +101,6 @@ export default function CreateModal({
     index: 0,
     count: steps.length,
   });
-
-  // Define the callback function to handle a 'List an item' button click
-  const handleListItemButtonClick = useCallback(() => {
-    if (user) {
-      onOpen();
-      setNewAddedItem((prev) => ({ ...prev, islost: true }));
-      setIsEdit(!isEdit);
-    } else {
-      onLoginModalOpen();
-    }
-  }, [user, onOpen, onLoginModalOpen, setNewAddedItem, isEdit, setIsEdit]);
-
-  // Define the JSX for the 'List an item' button
-  const listItemButton = (
-    <Button
-      // h={{ base: "10vh", md: "7vh" }}
-      // w={{ base: "40vw", md: "" }}
-      boxShadow="xl"
-      _hover={{ bg: "#b4dbd9" }}
-      backgroundColor="#33b249"
-      color="white"
-      fontSize="xl"
-      fontWeight="bold"
-      borderRadius={30}
-      size={"lg"}
-      paddingY={{ base: 10, md: 8 }}
-      onClick={handleListItemButtonClick}
-    >
-      <Text>List an item</Text>
-    </Button>
-  );
-
-  // Define the JSX for the 'Cancel (listing an item)' button
-  const cancelListItemButton = (
-    <Button
-      h={{ base: "8vh", md: "7vh" }}
-      w={{ base: "40vw", md: "8vw" }}
-      _hover={{ bg: "#F4C2C2" }}
-      backgroundColor="#B31B1B"
-      color="white"
-      fontSize="xl"
-      fontWeight="bold"
-      borderRadius={20}
-      onClick={() => {
-        setNewAddedItem({
-          image: "",
-          type: "",
-          islost: true,
-          name: "",
-          description: "",
-          itemdate: "",
-          isresolved: false,
-          ishelped: null,
-        });
-        setUploadImg("");
-        setActiveStep(0);
-        setIsCreate(true);
-        setIsEdit(false);
-        onClose();
-      }}
-    >
-      Cancel
-    </Button>
-  );
 
   // Define the JSX for the loading animation while an image is uploading
   const loadingAnimation = (
@@ -343,7 +278,6 @@ export default function CreateModal({
 
   return (
     <>
-      {isCreate ? listItemButton : cancelListItemButton}
       <Modal
         isOpen={isOpen}
         onClose={() => {

--- a/src/components/CreateModal/CreateModal.jsx
+++ b/src/components/CreateModal/CreateModal.jsx
@@ -43,6 +43,9 @@ import TypeSelector from "../TypeSelector/TypeSelector";
 import LostFoundSwitch from "./LostFoundSwitch";
 
 export default function CreateModal({
+  isOpen,
+  onOpen,
+  onClose,
   newAddedItem,
   setNewAddedItem,
   setIsCreate,
@@ -57,7 +60,6 @@ export default function CreateModal({
 }) {
   const { user } = UserAuth();
   const { onLoginModalOpen } = useContext(DataContext);
-  const { isOpen, onOpen, onClose } = useDisclosure();
   const [isLoading, setIsLoading] = useState(false);
 
   const uploadFile = useCallback(() => {

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -5,13 +5,14 @@ import { UserAuth } from "../../context/AuthContext";
 import DataContext from "../../context/DataContext";
 
 import { Spinner, useToast } from "@chakra-ui/react";
-import { AddIcon } from "@chakra-ui/icons";
+import { AddIcon, CloseIcon } from "@chakra-ui/icons";
 import {
   IconButton,
   Input,
   InputGroup,
   InputLeftAddon,
   Button,
+  ButtonGroup,
   Flex,
   HStack,
   Text,
@@ -607,21 +608,37 @@ export default function Home() {
         </Flex>
 
         <Flex position="absolute">
-          <IconButton
+          <ButtonGroup
             position="absolute"
             right="10"
             bottom="10"
-            height={75}
-            width={75}
             zIndex={1000}
-            isRound={true}
             variant="solid"
-            colorScheme="twitter"
-            aria-label="Add"
-            fontSize="30px"
-            icon={<AddIcon />}
-            onClick={handleListItemButtonClick}
-          />
+          >
+            {!isEdit ? (
+              <IconButton
+                height={75}
+                width={75}
+                isRound={true}
+                colorScheme="twitter"
+                aria-label="Add"
+                fontSize="30px"
+                icon={<AddIcon />}
+                onClick={handleListItemButtonClick}
+              />
+            ) : (
+              <IconButton
+                height={75}
+                width={75}
+                isRound={true}
+                colorScheme="red"
+                aria-label="Delete"
+                fontSize="30px"
+                icon={<CloseIcon />}
+                onClick={() => {}}
+              />
+            )}
+          </ButtonGroup>
           <Map
             newAddedItem={newAddedItem}
             setNewAddedItem={setNewAddedItem}

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -66,6 +66,7 @@ export default function Home() {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   // CREATE MODAL
+  // hoisted state
   const {
     isOpen: isOpenCreateModal,
     onOpen: onOpenCreateModal,

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -5,7 +5,9 @@ import { UserAuth } from "../../context/AuthContext";
 import DataContext from "../../context/DataContext";
 
 import { Spinner, useToast } from "@chakra-ui/react";
+import { AddIcon } from "@chakra-ui/icons";
 import {
+  IconButton,
   Input,
   InputGroup,
   InputLeftAddon,
@@ -61,6 +63,14 @@ export default function Home() {
   const toast = useToast();
 
   const { isOpen, onOpen, onClose } = useDisclosure();
+
+  // CREATE MODAL
+  const {
+    isOpen: isOpenCreateModal,
+    onOpen: onOpenCreateModal,
+    onClose: onCloseCreateModal,
+  } = useDisclosure();
+
   const {
     isOpen: isResultsBarOpen,
     onOpen: onResultsBarOpen,
@@ -167,6 +177,17 @@ export default function Home() {
     const dateA = new Date(a.date);
     const dateB = new Date(b.date);
     return dateB - dateA;
+  };
+
+  // Define the callback function to handle a 'List an item' button click
+  const handleListItemButtonClick = () => {
+    if (user) {
+      onOpenCreateModal();
+      setNewAddedItem((prev) => ({ ...prev, islost: true }));
+      setIsEdit(!isEdit);
+    } else {
+      onLoginModalOpen();
+    }
   };
 
   // Sort the array by date
@@ -407,6 +428,9 @@ export default function Home() {
 
           <Flex display={{ base: "none", md: "block" }}>
             <CreateModal
+              isOpen={isOpenCreateModal}
+              onOpen={onOpenCreateModal}
+              onClose={onCloseCreateModal}
               setIsCreate={setIsCreate}
               isCreate={isCreate}
               isEdit={isEdit}
@@ -581,7 +605,23 @@ export default function Home() {
             </Flex>
           )}
         </Flex>
+
         <Flex position="absolute">
+          <IconButton
+            position="absolute"
+            right="10"
+            bottom="10"
+            height={75}
+            width={75}
+            zIndex={1000}
+            isRound={true}
+            variant="solid"
+            colorScheme="twitter"
+            aria-label="Add"
+            fontSize="30px"
+            icon={<AddIcon />}
+            onClick={handleListItemButtonClick}
+          />
           <Map
             newAddedItem={newAddedItem}
             setNewAddedItem={setNewAddedItem}

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -622,7 +622,7 @@ export default function Home() {
                 width={75}
                 isRound={true}
                 colorScheme="twitter"
-                aria-label="Add"
+                aria-label="Add Item"
                 fontSize="30px"
                 icon={<AddIcon />}
                 onClick={handleListItemButtonClick}
@@ -633,10 +633,25 @@ export default function Home() {
                 width={75}
                 isRound={true}
                 colorScheme="red"
-                aria-label="Delete"
+                aria-label="Cancel Adding Item"
                 fontSize="30px"
                 icon={<CloseIcon />}
-                onClick={() => {}}
+                onClick={() => {
+                  setNewAddedItem({
+                    image: "",
+                    type: "",
+                    islost: true,
+                    name: "",
+                    description: "",
+                    itemdate: "",
+                    isresolved: false,
+                    ishelped: null,
+                  });
+                  setUploadImg("");
+                  setIsCreate(true);
+                  setIsEdit(false);
+                  onClose();
+                }}
               />
             )}
           </ButtonGroup>


### PR DESCRIPTION
### Overview

Deleted old list item button and unlist item button. Replaced with blue + button and red X button to bottom right corner of the map. This is for a more minimalistic design and removes clutter from the top left of screen. I believe it is common to have the user profile be in the top right, so it can collapse into a hamburger menu in mobile view.

### Details

- hoisted `createModal` `useDisclosure` state hook to `Home.jsx`
- "moved" over `onClick` functions for buttons to new buttons

### Commentary

- could improve on the animations (hover, active, etc.) and overall design of buttons, but I believe that would be out of the scope of this PR and should be handle in a future PR


<img width="1364" alt="Screenshot 2024-02-23 at 4 46 26 AM" src="https://github.com/icssc/zotnfound-frontend/assets/66880934/2e0c78b0-cd93-4fce-af58-8a054772b549">
<img width="391" alt="Screenshot 2024-02-23 at 4 47 18 AM" src="https://github.com/icssc/zotnfound-frontend/assets/66880934/daa80265-3dbd-4539-8e60-5855bbfd1532">

<img width="176" alt="Screenshot 2024-02-23 at 4 46 39 AM" src="https://github.com/icssc/zotnfound-frontend/assets/66880934/46a0557e-da0c-4481-b678-a75136414da5">
