### PR TITLE
feat: tooltip + ListItemButton

### DIFF
--- a/src/components/CreateModal/CreateModal.jsx
+++ b/src/components/CreateModal/CreateModal.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   Image,
   Button,
@@ -295,6 +295,7 @@ export default function CreateModal({
         }}
         size={"4xl"}
         closeOnOverlayClick={false}
+        finalFocusRef={{}}
       >
         <ModalOverlay>
           <ModalContent minHeight="50vh">

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -5,9 +5,8 @@ import { UserAuth } from "../../context/AuthContext";
 import DataContext from "../../context/DataContext";
 
 import { Spinner, useToast } from "@chakra-ui/react";
-import { AddIcon, CloseIcon } from "@chakra-ui/icons";
+
 import {
-  IconButton,
   Input,
   InputGroup,
   InputLeftAddon,
@@ -53,6 +52,7 @@ import LoginModal from "../LoginModal/LoginModal";
 import Leaderboard from "./Leaderboard";
 import ZotNFoundLogoText from "./ZotNFoundLogoText";
 import DateRangeFilter from "./DateRangeFilter";
+import ListItemButton from "./ListItemButton";
 
 export default function Home() {
   const [search, setSearch] = useState("");
@@ -198,6 +198,23 @@ export default function Home() {
     } else {
       onLoginModalOpen();
     }
+  };
+
+  const handleCancelItemButtonClick = () => {
+    setNewAddedItem({
+      image: "",
+      type: "",
+      islost: true,
+      name: "",
+      description: "",
+      itemdate: "",
+      isresolved: false,
+      ishelped: null,
+    });
+    setUploadImg("");
+    setIsCreate(true);
+    setIsEdit(false);
+    onClose();
   };
 
   // Sort the array by date
@@ -637,52 +654,16 @@ export default function Home() {
         </Flex>
 
         <Flex position="absolute">
-          <ButtonGroup
+          <ListItemButton
+            switchState={!isEdit}
+            addCallback={handleListItemButtonClick}
+            cancelCallback={handleCancelItemButtonClick}
             position="absolute"
-            right="10"
-            bottom="10"
+            right={10}
+            bottom={10}
             zIndex={1000}
             variant="solid"
-          >
-            {!isEdit ? (
-              <IconButton
-                height={75}
-                width={75}
-                isRound={true}
-                colorScheme="twitter"
-                aria-label="Add Item"
-                fontSize="30px"
-                icon={<AddIcon />}
-                onClick={handleListItemButtonClick}
-              />
-            ) : (
-              <IconButton
-                height={75}
-                width={75}
-                isRound={true}
-                colorScheme="red"
-                aria-label="Cancel Adding Item"
-                fontSize="30px"
-                icon={<CloseIcon />}
-                onClick={() => {
-                  setNewAddedItem({
-                    image: "",
-                    type: "",
-                    islost: true,
-                    name: "",
-                    description: "",
-                    itemdate: "",
-                    isresolved: false,
-                    ishelped: null,
-                  });
-                  setUploadImg("");
-                  setIsCreate(true);
-                  setIsEdit(false);
-                  onClose();
-                }}
-              />
-            )}
-          </ButtonGroup>
+          />
           <Map
             newAddedItem={newAddedItem}
             setNewAddedItem={setNewAddedItem}

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -661,8 +661,6 @@ export default function Home() {
             position="absolute"
             right={10}
             bottom={10}
-            zIndex={1000}
-            variant="solid"
           />
           <Map
             newAddedItem={newAddedItem}

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -543,10 +543,10 @@ export default function Home() {
             <Flex gap="4">
               <ButtonGroup
                 variant="outline"
-                colorScheme="twitter"
+                colorScheme="#74a2fa"
                 color="#5f85cf"
                 spacing={3}
-                boxShadow="5px 2px 9px rgba(0, 0, 0, 0.2);"
+                // boxShadow="5px 2px 9px rgba(0, 0, 0, 0.2);"
               >
                 <Button
                   backgroundColor="white"

--- a/src/components/Home/ListItemButton.jsx
+++ b/src/components/Home/ListItemButton.jsx
@@ -1,7 +1,6 @@
 import { AddIcon, CloseIcon } from "@chakra-ui/icons";
 
 import { IconButton, Tooltip, ButtonGroup } from "@chakra-ui/react";
-import { useEffect } from "react";
 
 export default function ListItemButton({
   switchState,
@@ -11,14 +10,16 @@ export default function ListItemButton({
 }) {
   return (
     <ButtonGroup {...props}>
-      {switchState ? (
-        <Tooltip
-          label="Make Post"
-          aria-label="Add Item Tooltip"
-          placement="top"
-          openDelay={300}
-          fontSize="xl"
-        >
+      <Tooltip
+        label={switchState ? "Make Post" : "Cancel Post"}
+        aria-label="Item Tooltip"
+        placement="top"
+        openDelay={500}
+        closeOnClick
+        closeOnPointerDown
+        fontSize="xl"
+      >
+        {switchState ? (
           <IconButton
             height={75}
             width={75}
@@ -29,15 +30,7 @@ export default function ListItemButton({
             icon={<AddIcon />}
             onClick={addCallback}
           />
-        </Tooltip>
-      ) : (
-        <Tooltip
-          label="Cancel Post"
-          aria-label="Cancel Item Tooltip"
-          placement="top"
-          openDelay={300}
-          fontSize="xl"
-        >
+        ) : (
           <IconButton
             height={75}
             width={75}
@@ -48,8 +41,8 @@ export default function ListItemButton({
             icon={<CloseIcon />}
             onClick={cancelCallback}
           />
-        </Tooltip>
-      )}
+        )}
+      </Tooltip>
     </ButtonGroup>
   );
 }

--- a/src/components/Home/ListItemButton.jsx
+++ b/src/components/Home/ListItemButton.jsx
@@ -1,0 +1,55 @@
+import { AddIcon, CloseIcon } from "@chakra-ui/icons";
+
+import { IconButton, Tooltip, ButtonGroup } from "@chakra-ui/react";
+import { useEffect } from "react";
+
+export default function ListItemButton({
+  switchState,
+  addCallback,
+  cancelCallback,
+  ...props
+}) {
+  return (
+    <ButtonGroup {...props}>
+      {switchState ? (
+        <Tooltip
+          label="Make Post"
+          aria-label="Add Item Tooltip"
+          placement="top"
+          openDelay={300}
+          fontSize="xl"
+        >
+          <IconButton
+            height={75}
+            width={75}
+            isRound={true}
+            colorScheme="twitter"
+            aria-label="Add Item"
+            fontSize="30px"
+            icon={<AddIcon />}
+            onClick={addCallback}
+          />
+        </Tooltip>
+      ) : (
+        <Tooltip
+          label="Cancel Post"
+          aria-label="Cancel Item Tooltip"
+          placement="top"
+          openDelay={300}
+          fontSize="xl"
+        >
+          <IconButton
+            height={75}
+            width={75}
+            isRound={true}
+            colorScheme="red"
+            aria-label="Cancel Adding Item"
+            fontSize="30px"
+            icon={<CloseIcon />}
+            onClick={cancelCallback}
+          />
+        </Tooltip>
+      )}
+    </ButtonGroup>
+  );
+}

--- a/src/components/Home/ListItemButton.jsx
+++ b/src/components/Home/ListItemButton.jsx
@@ -14,7 +14,7 @@ export default function ListItemButton({
         label={switchState ? "Make Post" : "Cancel Post"}
         aria-label="Item Tooltip"
         placement="top"
-        openDelay={500}
+        openDelay={300}
         closeOnClick
         closeOnPointerDown
         fontSize="xl"
@@ -24,7 +24,11 @@ export default function ListItemButton({
             height={75}
             width={75}
             isRound={true}
-            colorScheme="twitter"
+            backgroundColor="#74a2fa"
+            color={"white"}
+            _hover={{
+              background: "#365fad",
+            }}
             aria-label="Add Item"
             fontSize="30px"
             icon={<AddIcon />}

--- a/src/components/Home/ListItemButton.jsx
+++ b/src/components/Home/ListItemButton.jsx
@@ -9,7 +9,7 @@ export default function ListItemButton({
   ...props
 }) {
   return (
-    <ButtonGroup {...props}>
+    <ButtonGroup {...props} zIndex={1000} variant="solid">
       <Tooltip
         label={switchState ? "Make Post" : "Cancel Post"}
         aria-label="Item Tooltip"


### PR DESCRIPTION
### Overview

- tooltip for Add and Cancel Item Button
- created component to compartmentalize

### Details

- `onPointerClose` and `onClickClose` are necessary to prevent Cancel Item Button tooltip from flashing `onClick`
- tooltip comes back `onModalClose` because when modal closes, focus goes back to the modal trigger which is the `ListItemButton`, re-triggering the tooltip (I removed it, but if it looks better without it then we should keep it)

### Other Notes

I think for refactoring in general we should try to compartmentalize large component files, like this PR does, (create more component files with less lines) for cleaner code quality, because components should not be 100s of lines long. Perhaps we can talk about this in meeting.
