### PR TITLE
feat: card enhancements

### DIFF
--- a/src/components/ResultCard/ResultCard.jsx
+++ b/src/components/ResultCard/ResultCard.jsx
@@ -58,7 +58,14 @@ const ResultCard = React.memo(
     );
     return (
       <>
-        <Card maxW="lg" align={"center"} mb="10px">
+        <Card
+          bg="gray.50"
+          border="1px"
+          borderColor="gray.300"
+          maxW="lg"
+          align={"center"}
+          mb="10px"
+        >
           <CardBody>
             <Flex justifyContent={"center"} alignItems={"center"}>
               {props.isresolved && (
@@ -79,7 +86,13 @@ const ResultCard = React.memo(
                   </Text>
                 </Flex>
               )}
-              <Image rounded={"lg"} src={props.image} loading="lazy" />
+              <Image
+                border="1px"
+                borderColor="gray.300"
+                rounded={"lg"}
+                src={props.image}
+                loading="lazy"
+              />
             </Flex>
             <Stack mt="6" spacing="3">
               <Flex justifyContent={"space-between"}>
@@ -96,11 +109,11 @@ const ResultCard = React.memo(
           <CardFooter>
             <Flex justifyContent={"space-between"}>
               <Button
-                variant="ghost"
+                variant="outline"
                 colorScheme="blue"
                 leftIcon={<InfoIcon />}
                 size="md"
-                w="20"
+                w="60%"
                 onClick={infoModalDisclosure.onOpen}
               >
                 View

--- a/src/components/ResultsBar/ResultsBar.jsx
+++ b/src/components/ResultsBar/ResultsBar.jsx
@@ -54,6 +54,7 @@ export default function ResultsBar({
           _hover={{
             transform: "scale(0.99)",
           }}
+          transition="transform .3s ease"
         >
           <ResultCard
             props={item}


### PR DESCRIPTION
### Overview

- made view button wider and changed to `outline` variant (previously, button was too small, so when it was on `ghost` variant the blue hover was noticeably narrow)
- added subtle borders to card and image
- added subtle background color
- added transition to hover animation

##### New
<img width="619" alt="Screenshot 2024-02-27 at 9 02 06 PM" src="https://github.com/icssc/zotnfound-frontend/assets/66880934/34c867f7-4a0b-4a87-800c-4d829baeba49">

##### Old
<img width="311" alt="Screenshot 2024-02-27 at 9 02 31 PM" src="https://github.com/icssc/zotnfound-frontend/assets/66880934/58af363f-418d-4a29-bf8d-7c48c3f54936">

