### PR TITLE
Header Responsiveness and Formatting

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -327,7 +327,7 @@ export default function Home() {
           w={{ base: "100%", md: "40%" }}
           display={{ base: "none", md: "block" }}
         >
-          <InputGroup mt="1%" size={{ base: "md", md: "lg" }} mb="1%">
+          <InputGroup mt="1%" size={{ base: "md", md: "lg" }} mb="1%" padding={8}>
             <InputLeftAddon children="🔎" />
             <Input
               type="teal"


### PR DESCRIPTION
Fixed emblem dip by changing the base user pfp size
<img width="278" alt="image" src="https://github.com/icssc/zotnfound-frontend/assets/58576326/59a6f004-76ad-4044-9623-077c6ea6e2e9">

Fix item overlapping at breakpoint of layout shift with padding
<img width="557" alt="image" src="https://github.com/icssc/zotnfound-frontend/assets/58576326/b6076010-e851-4ad0-8851-77c94502699d">

Closes #50